### PR TITLE
FastAPIを導入

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,19 @@
+import os
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+origins = [
+     os.getenv("ACSESS_ALLOW_URL"),  # フロントのオリジン
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,  # 許可するオリジンのリスト
+    allow_credentials=True,
+    allow_methods=["*"],  # すべてのメソッドを許可
+    allow_headers=["*"],  # すべてのヘッダーを許可
+)
+
+#app.include_router()

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,1 @@
+fastapi


### PR DESCRIPTION
## 目的
FastAPIを使ってAPIサーバーを建てる。

## 概要
-  main.pyを作成
- FastAPIを導入しAPIサーバーが建つようにした
- APIアクセスできるオリジンのリストをenvファイルから取得

## 確認項目
- [ ] 以下コマンドでエラーが発生することなく、dockerコンテナが建つ
```
% docker compose build
% docker compose up
```
- [ ] ポート9004でAPIサーバーが経つ(http://localhost:9004/docs)


## 不安・相談