### PR TITLE
フィボナッチ数を取得するAPIを実装.なお、メモリや計算速度は考慮していない

### DIFF
--- a/api/libs/math/fibonacci_number/generate_fibonacci_number.py
+++ b/api/libs/math/fibonacci_number/generate_fibonacci_number.py
@@ -1,0 +1,21 @@
+def generate_fibonacci_number(fibonacci_index:int):
+    """
+    指定された順番のフィボナッチ数を生成する関数
+    ex. n=1 -> 1, n=5 -> 8, n=6 -> 13 n=7 -> 21
+    Args:
+        fibonacci_index (int) : single_value_model.value
+                                                -> フィボナッチ数列の順番を指定する値.1で先頭のフィボナッチ数を指定する
+    Returns:
+        generate_fibonacci_number(fibonacci_index -1) + generate_fibonacci_number(fibonacci_index -2) (int) : 指定された番目のフィボナッチ数
+    Raises:
+        HTTP_400_BAD_REQUEST:
+    """
+
+    # フィボナッチ数を計算
+    # n番目のフィボナッチ数はn-1番目とn-2番目を足したものであり、1番目のフィボナッチ数は1,0番目以下は0とすることで値が収束する
+    if fibonacci_index <= 0:
+        return 0
+    elif fibonacci_index == 1:
+        return 1
+    else:
+        return generate_fibonacci_number(fibonacci_index -1) + generate_fibonacci_number(fibonacci_index -2)

--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,7 @@
 import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from routers import fibonacci_api_handler
 
 app = FastAPI()
 
@@ -16,4 +17,4 @@ app.add_middleware(
     allow_headers=["*"],  # すべてのヘッダーを許可
 )
 
-#app.include_router()
+app.include_router(fibonacci_api_handler.router)

--- a/api/models.py
+++ b/api/models.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel, Field
+
+class FibonacciResultModel(BaseModel):
+    """
+    "フィボナッチ数を出力するAPI"の出力model.
+    BaseModelで検証を行う.
+
+    variable:
+        result (int) : ある番目におけるフィボナッチ数.１以上の整数.
+    """
+    result: int = Field(..., gt=0)
+
+    def __init__(self, **data):
+        super().__init__(**data)
+
+class FibonacciValueModel(BaseModel):
+    """
+    フィボナッチ数の番目を指定するmodel.
+    BaseModelで検証を行う.
+
+    variable:
+        n (int) : フィボナッチ数の番目を指定する値.１以上の整数.
+    """
+    n: int = Field(..., gt=0)
+
+    def __init__(self, **data):
+        super().__init__(**data)

--- a/api/routers/fibonacci_api_handler.py
+++ b/api/routers/fibonacci_api_handler.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends
+from libs.math.fibonacci_number.generate_fibonacci_number import generate_fibonacci_number
+from models import FibonacciResultModel,FibonacciValueModel
+
+router = APIRouter()
+
+@router.get("/fib")
+def fibonacci_api_handler(input_value_model: FibonacciValueModel = Depends()) -> FibonacciResultModel:
+    """
+    指定された順番のフィボナッチ数を生成するルーター
+    ex. n=1 -> 1, n=6 -> 8, n=7 -> 13 n=8 -> 21
+    Args:
+        input_value_model (FibonacciValueModel) : input_value_model.n
+                                                    -> フィボナッチ数列の順番を指定する値.1で先頭のフィボナッチ数を指定する
+    Returns:
+        FibonacciResultModel(result = fibonacci_number) (FibonacciResultModel) : 指定された番目のフィボナッチ数
+    Raises:
+        HTTP_422_UNPROCESSABLE_ENTITY: リクエストの内容が不正
+        HTTP_500_INTERNAL_SERVER_ERROR: nが大きい際、再起的読み込みによって発生するエラー(スタックオーバーフロー等)
+    """
+
+    # n番目のフィボナッチ数を取得
+    fibonacci_number:int = generate_fibonacci_number(input_value_model.n)
+
+    return FibonacciResultModel(result = fibonacci_number)


### PR DESCRIPTION
## 目的
フィボナッチ数を取得するAPIを実装.

## 概要
 - フィボナッチ数を生成する関数を実装
 - フィボナッチ数を取得するAPIを実装
 - 上記APIに対してBasemodelでの検証を導入

## 確認項目
 - [x] APIサーバーが建つ
 - [x] 以下のコマンドを実行し、
```
curl -X 'GET' \
  'http://localhost:9004/fib?n=8' \
  -H 'accept: application/json'
```
以下のようなレスポンスが得られる
```
{"result":21}
```
 - [x] 以下のコマンドを実行し、422エラーが発生する
```
curl -X 'GET' \
  'http://localhost:9004/fib?n=0' \
  -H 'accept: application/json'
```

 - [x] 以下のコマンドを実行し、422エラーが発生する
```
curl -X 'GET' \
  'http://localhost:9004/fib?n=a' \
  -H 'accept: application/json'
```
## 不安
メモリや計算速度を考慮していないから、後ほど改修が必要