### PR TITLE
ACSESS_ALLOW_URLで複数のオリジンを指定できるように変更

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,18 +1,24 @@
 import os
+from typing import Optional
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from routers import fibonacci_api_handler
 
 app = FastAPI()
 
-origins = [
-     os.getenv("ACSESS_ALLOW_URL"),  # フロントのオリジン
-]
+# 環境変数から"アクセスを許可するオリジン"を取得
+access_allow_urls:Optional[str] = os.getenv("ACSESS_ALLOW_URL")
+
+if access_allow_urls:
+    # セミコロンで区切られたパスをリストに変換
+    origins = access_allow_urls.split(';')
+
+print("******************")
+print(origins)
 
 app.add_middleware(
     CORSMiddleware,
-    #allow_origins=origins,  # 許可するオリジンのリスト
-    allow_origins=["*"], # 全てのオリジンからのアクセスを許可
+    allow_origins=origins,  # 許可するオリジンのリスト
     allow_credentials=True,
     allow_methods=["*"],  # すべてのメソッドを許可
     allow_headers=["*"],  # すべてのヘッダーを許可

--- a/api/main.py
+++ b/api/main.py
@@ -11,7 +11,8 @@ origins = [
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,  # 許可するオリジンのリスト
+    #allow_origins=origins,  # 許可するオリジンのリスト
+    allow_origins=["*"], # 全てのオリジンからのアクセスを許可
     allow_credentials=True,
     allow_methods=["*"],  # すべてのメソッドを許可
     allow_headers=["*"],  # すべてのヘッダーを許可


### PR DESCRIPTION
## 目的
ACSESS_ALLOW_URLで複数のオリジンを指定できるようにする

## 概要
-  ACSESS_ALLOW_URLをセミコロンでスライスし、オリジンに読み込む

## 確認項目
- [x] envファイルの ACSESS_ALLOW_URLを変更するとoriginが変わることを確認

## 不安・相談
