### PR TITLE
ACSESS_ALLOW_URLが定義されていない場合の処理を記述

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -13,9 +13,6 @@ if access_allow_urls:
     # セミコロンで区切られたパスをリストに変換
     origins = access_allow_urls.split(';')
 
-print("******************")
-print(origins)
-
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,  # 許可するオリジンのリスト

--- a/api/main.py
+++ b/api/main.py
@@ -11,7 +11,9 @@ access_allow_urls:Optional[str] = os.getenv("ACSESS_ALLOW_URL")
 
 if access_allow_urls:
     # セミコロンで区切られたパスをリストに変換
-    origins = access_allow_urls.split(';')
+    origins:list[str] = access_allow_urls.split(';')
+else:
+    origins:list[None] = []
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## 目的
- 消し忘れていたprint()を削除
- ACSESS_ALLOW_URLが定義されていない場合の処理を記述

## 概要
-  originの確認に使用したprint文を削除
- ACSESS_ALLOW_URLが定義されていない場合、全てのオリジンからのアクセスを拒否するように設定

## 確認項目
- [x] main.pyから不要なprint文が消えている
- [x] envファイルで ACSESS_ALLOW_URLが定義されていない場合originが[]になる

## 不安
