### PR TITLE
generate_fibonacci_number.pyで使用する検証関数を実装

### DIFF
--- a/api/app/libs/math/fibonacci_number/generate_fibonacci_number.py
+++ b/api/app/libs/math/fibonacci_number/generate_fibonacci_number.py
@@ -1,3 +1,5 @@
+from app.libs.math.fibonacci_number import validate_fibonacci
+
 def generate_fibonacci_number(fibonacci_index:int):
     """
     指定された順番のフィボナッチ数を生成する関数
@@ -8,8 +10,12 @@ def generate_fibonacci_number(fibonacci_index:int):
     Returns:
         generate_fibonacci_number(fibonacci_index -1) + generate_fibonacci_number(fibonacci_index -2) (int) : 指定された番目のフィボナッチ数
     Raises:
-        HTTP_400_BAD_REQUEST:
+        ValueError: フィボナッチ数のインデックスが有効範囲外 or インデックスが数値ではない
     """
+
+    # フィボナッチ数の番数が不正な値でなはないか検証
+    if not validate_fibonacci.fib_index(fibonacci_index):
+        raise ValueError("Invalid index for Fibonacci number")
 
     # フィボナッチ数を計算
     # n番目のフィボナッチ数はn-1番目とn-2番目を足したものであり、1番目のフィボナッチ数は1,0番目以下は0とすることで値が収束する

--- a/api/app/libs/math/fibonacci_number/validate_fibonacci.py
+++ b/api/app/libs/math/fibonacci_number/validate_fibonacci.py
@@ -1,0 +1,15 @@
+def fib_index(index: int) -> bool:
+    """
+    フィボナッチ数のindexが不正ではないか検証
+    本来、index=0は存在しないが、generate_fibonacci_numberは計算にindex=0を使用するため、0を許可
+    Args:
+        index (int): フィボナッチ数列のインデックス
+    Returns:
+        (bool): indexが0以上の整数であればTrue、そうでなければFalse
+    """
+
+    # 0以上の整数ならTrue,0未満 or 整数ではない場合はFalse
+    if isinstance(index, int) and index >= 0:
+        return True
+    else:
+        return False

--- a/api/app/routers/fibonacci_api_handler.py
+++ b/api/app/routers/fibonacci_api_handler.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends,HTTPException
 from app.libs.math.fibonacci_number.generate_fibonacci_number import generate_fibonacci_number
 from models import FibonacciResultModel,FibonacciValueModel
 
@@ -15,11 +15,15 @@ def fibonacci_api_handler(input_value_model: FibonacciValueModel = Depends()) ->
     Returns:
         FibonacciResultModel(result = fibonacci_number) (FibonacciResultModel) : 指定された番目のフィボナッチ数
     Raises:
-        HTTP_422_UNPROCESSABLE_ENTITY: リクエストの内容が不正
+        HTTP_422_UNPROCESSABLE_ENTITY: リクエストの内容が不正 or フィボナッチ数を生成する関数が値を処理できなかった
         HTTP_500_INTERNAL_SERVER_ERROR: nが大きい際、再起的読み込みによって発生するエラー(スタックオーバーフロー等)
     """
 
     # n番目のフィボナッチ数を取得
-    fibonacci_number:int = generate_fibonacci_number(input_value_model.n)
+    try:
+        fibonacci_number:int = generate_fibonacci_number(input_value_model.n)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
 
     return FibonacciResultModel(result = fibonacci_number)

--- a/api/test/libs/math/fibonacci_number/test_generate_fibonacci_number.py
+++ b/api/test/libs/math/fibonacci_number/test_generate_fibonacci_number.py
@@ -18,5 +18,11 @@ def test_generate_fibonacci_number():
     # エッジケース
     assert generate_fibonacci_number(0) == 0  # 0番目は0を返すべき
 
-    # 負の数に対するテスト
-    assert generate_fibonacci_number(-1) == 0  # 負の数に対しては0を返すべき
+    # 異常なケース
+    with pytest.raises(ValueError):  # 負の値に対してはValueErrorが発生
+        generate_fibonacci_number(-1)
+    with pytest.raises(ValueError):  # 文字列に対してはValueErrorが発生
+        generate_fibonacci_number("a")
+    with pytest.raises(ValueError):  #配列に対してはValueErrorが発生
+        generate_fibonacci_number([1,2,3,4])
+        

--- a/api/test/libs/math/fibonacci_number/test_validate_fibonacci.py
+++ b/api/test/libs/math/fibonacci_number/test_validate_fibonacci.py
@@ -1,0 +1,25 @@
+import pytest
+from app.libs.math.fibonacci_number.validate_fibonacci import fib_index
+
+def test_fib_index():
+    """
+
+    """
+    # 正常なケース
+    assert fib_index(1) == True  # 1以上の整数
+    assert fib_index(10) == True  # 1以上の整数
+
+    # エッジケース
+    assert fib_index(0) == True
+
+    # 異常なケース
+    assert fib_index(-1) == False # 負の数
+    assert fib_index(1.1) == False # 浮動少数
+    assert fib_index("1") == False # 文字列
+    assert fib_index("very long string" * 10000) == False # 非常に大きな文字列
+    assert fib_index(None) == False # None
+    assert fib_index([1]) == False # リスト
+    assert fib_index({'index': 1}) == False # 辞書
+    assert fib_index((5,)) == False # タプル
+    assert fib_index(object()) == False # オブジェクト
+


### PR DESCRIPTION
## 目的
generate_fibonacci_number.pyで使用する検証関数とそのテストを実装

## 概要
- generate_fibonacci_number.pyで使用する検証関数validate_fibonacci.pyを実装
- validate_fibonacci.pyのユニットテストtest_validate_fibonacci.pyを実装
- validate_fibonacci.pyの実装に伴い、エラーハンドリングを追加
- test_generate_fibonacci_number.pyのテストケースを一部変更

## 確認項目
- [x] APIサーバーが建つ
- [x] 以下のコマンドを実行し、
```
curl -X 'GET' \
  'http://localhost:9004/fib?n=8' \
  -H 'accept: application/json'
```
以下のようなレスポンスが得られる
```
{"result":21}
```
- [x] /apiで以下のコマンドを実行し、ユニットテストが3つ実行される.
```
pytest
```
- [x] ユニットテストが通る
## 不安
