### PR TITLE
fibonacci_api_handlerに500エラーを追加

### DIFF
--- a/api/app/routers/fibonacci_api_handler.py
+++ b/api/app/routers/fibonacci_api_handler.py
@@ -23,7 +23,10 @@ def fibonacci_api_handler(input_value_model: FibonacciValueModel = Depends()) ->
     try:
         fibonacci_number:int = generate_fibonacci_number(input_value_model.n)
     except ValueError as e:
+        # input_value_model.nが1以上の整数ではない
         raise HTTPException(status_code=422, detail=str(e))
-
+    except RecursionError as e:
+        # スタックオーバーフロー
+        raise HTTPException(status_code=500, detail=str(e))
 
     return FibonacciResultModel(result = fibonacci_number)

--- a/api/test/routers/test_fibonacci_api_handler.py
+++ b/api/test/routers/test_fibonacci_api_handler.py
@@ -69,4 +69,8 @@ def test_fibonacci_api_handler():
     response = client.get("/fib?n="+"very_long_string" * 4000)
     assert response.status_code == 422
 
+    # 極端に大きな数を渡したケース、500エラーを期待
+    response = client.get("/fib?n=1000000")
+    assert response.status_code == 500
+
 


### PR DESCRIPTION
## 目的
fibonacci_api_handlerに500エラーを追加

## 概要
- fibonacci_api_handlerに500エラーを追加
- test_fibonacci_api_handlerのテストケースに500エラーを追加

## 確認項目
- [x] /apiで以下のコマンドを実行し、ユニットテストが3つ実行される.
```
pytest
```
- [x] ユニットテストが通る

## 不安・相談