### PR TITLE
フィボナッチ数を計算するアルゴリズムを変更

### DIFF
--- a/api/app/libs/math/fibonacci_number/generate_fibonacci_number.py
+++ b/api/app/libs/math/fibonacci_number/generate_fibonacci_number.py
@@ -10,7 +10,6 @@ def generate_fibonacci_number(fibonacci_index:int):
         (int) : 指定された番目のフィボナッチ数.fibonacci_index = 0 の返り値は0.
     Raises:
         ValueError: フィボナッチ数のインデックスが有効範囲外 or インデックスが数値ではない
-        RecursionError: スタックオーバーフロー
     """
 
     # フィボナッチ数の番数が不正な値でなはないか検証
@@ -19,9 +18,13 @@ def generate_fibonacci_number(fibonacci_index:int):
 
     # フィボナッチ数を計算
     # n番目のフィボナッチ数はn-1番目とn-2番目を足したものであり、1番目のフィボナッチ数は1,0番目以下は0とすることで値が収束する
-    if fibonacci_index <= 0:
-        return 0
-    elif fibonacci_index == 1:
-        return 1
+    if fibonacci_index:
+        current_value:int = 1
+        next_value:int = 1
+
+        for _ in range(1, fibonacci_index):
+            current_value, next_value = next_value, current_value + next_value
+        return current_value
     else:
-        return generate_fibonacci_number(fibonacci_index -1) + generate_fibonacci_number(fibonacci_index -2)
+        return 0
+

--- a/api/app/routers/fibonacci_api_handler.py
+++ b/api/app/routers/fibonacci_api_handler.py
@@ -16,7 +16,6 @@ def fibonacci_api_handler(input_value_model: FibonacciValueModel = Depends()) ->
         FibonacciResultModel(result = fibonacci_number) (FibonacciResultModel) : 指定された番目のフィボナッチ数
     Raises:
         HTTP_422_UNPROCESSABLE_ENTITY: リクエストの内容が不正 or フィボナッチ数を生成する関数が値を処理できなかった
-        HTTP_500_INTERNAL_SERVER_ERROR: nが大きい際、再起的読み込みによって発生するエラー(スタックオーバーフロー等)
     """
 
     # n番目のフィボナッチ数を取得
@@ -25,8 +24,5 @@ def fibonacci_api_handler(input_value_model: FibonacciValueModel = Depends()) ->
     except ValueError as e:
         # input_value_model.nが1以上の整数ではない
         raise HTTPException(status_code=422, detail=str(e))
-    except RecursionError as e:
-        # スタックオーバーフロー
-        raise HTTPException(status_code=500, detail=str(e))
 
     return FibonacciResultModel(result = fibonacci_number)

--- a/api/test/libs/math/fibonacci_number/test_generate_fibonacci_number.py
+++ b/api/test/libs/math/fibonacci_number/test_generate_fibonacci_number.py
@@ -13,7 +13,6 @@ def test_generate_fibonacci_number():
             (int) : 指定された番目のフィボナッチ数.fibonacci_index = 0 の返り値は0.
         Raises:
             ValueError: フィボナッチ数のインデックスが有効範囲外 or インデックスが数値ではない
-            RecursionError: スタックオーバーフロー
     """
 
     # 正常なケース

--- a/api/test/libs/math/fibonacci_number/test_generate_fibonacci_number.py
+++ b/api/test/libs/math/fibonacci_number/test_generate_fibonacci_number.py
@@ -25,13 +25,9 @@ def test_generate_fibonacci_number():
     assert generate_fibonacci_number(6) == 8  # 6番目のフィボナッチ数は8
     assert generate_fibonacci_number(10) == 55  # 10番目のフィボナッチ数は55
 
-
-    # 大きな値に対するテスト
-    # assert generate_fibonacci_number(50) == 12586269025  # 50番目のフィボナッチ数は12586269025
-
     # 非常に大きな値のテスト
     # 注意: このテストは実行時間が長くなる可能性があるため、実際の環境に応じて実施
-    # assert generate_fibonacci_number(99) == 218922995834555169026  # 99番目は218922995834555169026
+    assert generate_fibonacci_number(99) == 218922995834555169026  # 99番目は218922995834555169026
 
     # エッジケース
     assert generate_fibonacci_number(0) == 0  # 0番目は0を返すべき
@@ -61,9 +57,6 @@ def test_generate_fibonacci_number():
         
     with pytest.raises(ValueError):   # オブジェクト型
         generate_fibonacci_number(object())
-    
-    with pytest.raises(RecursionError): # 極端に大きな値
-        generate_fibonacci_number(1000000)
 
     with pytest.raises(ValueError):   # 非常に大きな文字列
         generate_fibonacci_number("very long string" * 100000)

--- a/api/test/routers/test_fibonacci_api_handler.py
+++ b/api/test/routers/test_fibonacci_api_handler.py
@@ -19,7 +19,6 @@ def test_fibonacci_api_handler():
             FibonacciResultModel(result = fibonacci_number) (FibonacciResultModel) : 指定された番目のフィボナッチ数
         Raises:
             HTTP_422_UNPROCESSABLE_ENTITY: リクエストの内容が不正
-            HTTP_500_INTERNAL_SERVER_ERROR: nが大きい際、再起的読み込みによって発生するエラー(スタックオーバーフロー等)
     """
     # 正常なケース
 
@@ -38,11 +37,16 @@ def test_fibonacci_api_handler():
     assert response.status_code == 200
     assert response.json() == {"result": 55}
 
-    # 非常に大きな値のテスト
+    # 大きな値のテスト
     # 注意: このテストは実行時間が長くなる可能性があるため、実際の環境に応じて実施
-    # response = client.get("/fib?n=99")
-    # assert response.status_code == 200
-    # assert response.json() == {"result": 218922995834555169026}
+    response = client.get("/fib?n=99")
+    assert response.status_code == 200
+    assert response.json() == {"result": 218922995834555169026}
+    
+    response = client.get("/fib?n=500")
+    assert response.status_code == 200
+    assert response.json() == {"result":139423224561697880139724382870407283950070256587697307264108962948325571622863290691557658876222521294125}
+
 
     # 異常なケース
 
@@ -77,7 +81,3 @@ def test_fibonacci_api_handler():
     # 非常に大きな文字列を渡したケース、422エラーを期待
     response = client.get("/fib?n="+"very_long_string" * 4000)
     assert response.status_code == 422
-
-    # 極端に大きな数を渡したケース、500エラーを期待
-    response = client.get("/fib?n=1000000")
-    assert response.status_code == 500


### PR DESCRIPTION
## 目的
フィボナッチ数を計算するアルゴリズムを変更し、計算量を抑える

## 概要
- generate_fibonacci_numberのアルゴリズムを動的計画法に変更
- 500エラーの記述を削除

## 確認項目
- [x] /apiで以下のコマンドを実行し、ユニットテストが3つ実行される.
```
pytest
```
- [x] ユニットテストが通る

## 不安・相談