### PR TITLE
cloudflareを実装.APIサーバーを公開できることとを確認.

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+  cloudflare:
+    image: "cloudflare/cloudflared:latest"
+    container_name: "cloudflare"
+    volumes: ["./web/prod:/home/nonroot/.cloudflared"]
+    command: tunnel run
+
+  api:
+    container_name: FastAPI
+    build:
+      context: ./api
+      dockerfile: api.Dockerfile
+    volumes:
+      - ./api:/api
+    ports:
+      - "9004:9004"
+    command: uvicorn app.main:app --reload --host 0.0.0.0 --port 9004
+    env_file:
+      - ./api.env

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,8 @@
+# Web
+デプロイ用ファイルを配置
+
+## Description
+- 必要ファイル
+  - config.yaml
+  - cert.pem
+  - {トンネルID}.json

--- a/web/prod/.gitignore
+++ b/web/prod/.gitignore
@@ -1,0 +1,3 @@
+*.json
+*.pem
+*.yaml


### PR DESCRIPTION
## 目的
cloudflareを実装し、APIサーバーを公開
## 概要
- デプロイ用にdocker-compose.prod.ymlを作成
- docker-compose.prod.ymにcloudflareコンテナを追加
- cloudflareの設定ファイルを入れるwebディレクトリをfib-api/に作成
- .gitignoreでcloudflareの設定ファイルを追跡から除外
- 

## 確認項目
- [x] 下記URLからフィボナッチ数を取得できる.
```
https://api.dishizawa.net/fib?n=10
```


## 不安・相談