### PR TITLE
response_modelを使用

### DIFF
--- a/api/app/routers/fibonacci_api_handler.py
+++ b/api/app/routers/fibonacci_api_handler.py
@@ -4,8 +4,8 @@ from models import FibonacciResultModel,FibonacciValueModel
 
 router = APIRouter()
 
-@router.get("/fib")
-def fibonacci_api_handler(input_value_model: FibonacciValueModel = Depends()) -> FibonacciResultModel:
+@router.get("/fib", response_model=FibonacciResultModel)
+def fibonacci_api_handler(input_value_model: FibonacciValueModel = Depends()) -> dict[str,int]:
     """
     指定された順番のフィボナッチ数を生成するルーター
     ex. n=1 -> 1, n=6 -> 8, n=7 -> 13 n=8 -> 21
@@ -25,4 +25,4 @@ def fibonacci_api_handler(input_value_model: FibonacciValueModel = Depends()) ->
         # input_value_model.nが1以上の整数ではない
         raise HTTPException(status_code=422, detail=str(e))
 
-    return FibonacciResultModel(result = fibonacci_number)
+    return {"result" : fibonacci_number}


### PR DESCRIPTION
## 目的
APIのレスポンスでresponse_modelを使用

## 概要
-  関数のresultでModelを使用するのではなく、response_modelでModelを指定する方法に変更

## 確認項目
- [x] /apiで以下のコマンドを実行し、ユニットテストで問題が検出されない。
```
pytest
```