### PR TITLE
ミドルウェアにloggerを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/__pycache__
 *.env
 **/.pytest_cache
+*.log

--- a/api/app/libs/utils/logger.py
+++ b/api/app/libs/utils/logger.py
@@ -1,11 +1,15 @@
-import logging
+import os
 import json
+import logging
 from fastapi import Request ,HTTPException
 from fastapi.responses import JSONResponse
 from starlette.responses import JSONResponse, StreamingResponse
 
+# 環境変数からlogファイルの名称を取得
+log_file_name = os.getenv('LOG_FILE_NAME', ".log")
+
 # ロギングの設定
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',filename='app.log',filemode='a')
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',filename=log_file_name,filemode='a')
 
 async def log_http_requests(request: Request, call_next):
     """

--- a/api/app/libs/utils/logger.py
+++ b/api/app/libs/utils/logger.py
@@ -1,0 +1,48 @@
+import logging
+import json
+from fastapi import Request ,HTTPException
+from fastapi.responses import JSONResponse
+from starlette.responses import JSONResponse, StreamingResponse
+
+# ロギングの設定
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',filename='app.log',filemode='a')
+
+async def log_http_requests(request: Request, call_next):
+    """
+    ミドルウェアとして機能する非同期関数.すべてのHTTPリクエストとレスポンスをログに記録する.
+    
+    Args:
+        request (Request): FastAPIによって受け取られるリクエストオブジェクト
+        call_next: リクエストオブジェクトを受け取り、次のリクエスト処理関数またはミドルウェアを呼び出すコールバック関数
+
+    Returns:
+        response: 処理後のレスポンスオブジェクト
+    """
+    # リクエストの受信をログに記録
+    logging.info(f"New request: {request.method} {request.url}")
+    try:
+        # 次のリクエストハンドラを非同期で呼び出し、レスポンスを待機
+        response = await call_next(request)
+        
+        if response.status_code == 422:
+            content = []
+            async for chunk in response.body_iterator:
+                content.append(chunk)
+            # JSONとしてデコード
+            details = json.loads(b''.join(content).decode())
+            # 'detail' キーからエラー詳細を取得しログに記録
+            error_details = details['detail']
+            logging.error(f"Error details: {error_details}")
+            # ステータスコードも元のレスポンスから取得して設定
+            response = StreamingResponse(iter(content), status_code=response.status_code, media_type=response.media_type)
+
+    except Exception as e:
+        # 例外が発生した場合はエラーをログに記録し、500エラーを生成
+        logging.error(f"Message: {str(e)}")
+        response = JSONResponse(status_code=500, content={"Message": "Server Error"})
+
+    finally:
+        # 最終的なレスポンスステータスをログに記録
+        logging.info(f"Response status: {response.status_code}")
+
+        return response

--- a/api/app/libs/utils/logger.py
+++ b/api/app/libs/utils/logger.py
@@ -28,7 +28,7 @@ async def log_http_requests(request: Request, call_next):
         # 次のリクエストハンドラを非同期で呼び出し、レスポンスを待機
         response = await call_next(request)
         
-        if response.status_code == 422:
+        if response.status_code != 200:
             content = []
             async for chunk in response.body_iterator:
                 content.append(chunk)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -3,8 +3,12 @@ from typing import Optional
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.routers import fibonacci_api_handler
+from app.libs.utils import logger
 
 app = FastAPI()
+
+# ロガーをミドルウェアとしてアプリに追加
+app.middleware("http")(logger.log_http_requests)
 
 # 環境変数から"アクセスを許可するオリジン"を取得
 access_allow_urls:Optional[str] = os.getenv("ACSESS_ALLOW_URL")


### PR DESCRIPTION
## 目的
ミドルウェアにloggerを追加

## 概要
- libs/utilsにloggerを記述
- mian.pyでミドルウェアにloggerを追加
- logファイルを.gitignoreで追跡から除外

## 確認項目
- [x] api.envに
```
LOG_FILE_NAME="api.log"
```
を記述
- [x] dockerコンテナを建てるとapi.logが生成されることを確認
- [x] 以下コマンドで
```
 % curl -X 'GET' \
  'http://localhost:9004/fib?n=100' \
  -H 'accept: application/json'
```
以下のログが記述されることを確認
```
{日時} - INFO - New request: GET http://localhost:9004/fib?n=100
{日時} - INFO - Response status: 200
```
- [x] 以下コマンドで
```
 % curl -X 'GET' \
  'http://localhost:9004/fib?n=0' \
  -H 'accept: application/json'
```
以下のログが記述されることを確認
```
{日時} - INFO - New request: GET http://localhost:9004/fib?n=0
{日時} - ERROR - Error details: [{'type': 'greater_than', 'loc': ['query', 'n'], 'msg': 'Input should be greater than 0', 'input': '0', 'ctx': {'gt': 0}}]
{日時} - INFO - Response status: 422
```

## 不安