### PR TITLE
負荷テストを実装

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 pytest
+httpx
+pytest-asyncio


### PR DESCRIPTION
## 目的
負荷テストを実装

## 概要
- 並行処理で負荷をかけるテストを実装

## 確認項目
- [x] /apiで以下のコマンドを実行し、ユニットテストが実行される.
```
pytest
```
- [x] ユニットテストが通る
## 不安
